### PR TITLE
feat: add `working-directory` input option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This GitHub action lets you push an Actor to the Apify platform, e.g. after ever
 
 **version** (optional): Actor version number to which the files should be pushed. By default, it is taken from the ".actor/actor.json" file.
 
-**working-directory** (optional): The working directory where the Actor files are located. By default, it is the root of the repository.
+**working-directory** (optional): The working directory where the `.actor` folder is located. By default, it is the root of the repository.
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This GitHub action lets you push an Actor to the Apify platform, e.g. after ever
 
 **version** (optional): Actor version number to which the files should be pushed. By default, it is taken from the ".actor/actor.json" file.
 
+**working-directory** (optional): The working directory where the Actor files are located. By default, it is the root of the repository.
+
 ## Example usage
 
 ```yaml
@@ -38,6 +40,7 @@ jobs:
         uses: apify/push-actor-action@master
         with:
           token: ${{ secrets.APIFY_TOKEN }}
+          working-directory: packages/apify-actor
 ```
 
 ## Examples of top Actors on Apify Store

--- a/action.yaml
+++ b/action.yaml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ''
   working-directory:
-    description: 'The working directory where the Actor files are located. By default, it is the root of the repository.'
+    description: 'The working directory where the `.actor` folder is located. By default, it is the root of the repository.'
     required: false
     default: ${{ github.workspace }}
 runs:

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: 'Actor version number to which the files should be pushed. By default, it is taken from the ".actor/actor.json" file.'
     required: false
     default: ''
+  working-directory:
+    description: 'The working directory where the Actor files are located. By default, it is the root of the repository.'
+    required: false
+    default: ${{ github.workspace }}
 runs:
   using: 'composite'
   steps:
@@ -36,6 +40,7 @@ runs:
         apify login -t ${{ inputs.token }}
     - name: Push the Actor
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         push_args=()
 


### PR DESCRIPTION
Enables the use of this action in monorepos (and other non-top-level-Actor setups).

Closes #10 