### PR TITLE
fix: Add explicit wait to apify push

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -68,7 +68,17 @@ runs:
         build_json_file=$(mktemp)
         # Write JSON to a temp file instead of capturing in a bash variable
         # to avoid truncation issues with large outputs (e.g. embedded readmes)
-        apify push --json "${push_args[@]}" > "$build_json_file"
+        #
+        # --wait-for-finish makes `apify push` block until the build reaches a
+        # terminal status. Without it, the command can return while the build is
+        # still RUNNING, making the status check below fail spuriously.
+        #
+        # An explicit value (in seconds) is required: passing the bare
+        # `--wait-for-finish` flag is ambiguous to the CLI's argument parser and
+        # would swallow the next positional (the actor-id) as its value. 999999s
+        # (~11.5 days) far exceeds any GitHub Actions or Apify build timeout, so
+        # in practice it waits until the build finishes.
+        apify push --json --wait-for-finish=999999 "${push_args[@]}" > "$build_json_file"
 
         if ! jq empty "$build_json_file" 2>/dev/null; then
           echo "::error::Failed to parse JSON output from 'apify push'. Output was:"


### PR DESCRIPTION
The action used to randomly fail because of a stale `.status` field:

- **janbuchar/actor-mpsv-social-services** — [run 26830076394](https://github.com/janbuchar/actor-mpsv-social-services/actions/runs/26830076394)
- **apify/actor-scrapy-books-example** — [Push to Apify, run 26530930471](https://github.com/apify/actor-scrapy-books-example/actions/runs/26530930471)
- **apify/example-code-runner-py** — [Push to Apify, run 26530211755](https://github.com/apify/example-code-runner-py/actions/runs/26530211755)
- **apify/actor-ci-origin-test** — [Push to Apify (staging), run 26230179782](https://github.com/apify/actor-ci-origin-test/actions/runs/26230179782)

All four: CLI emitted `RUNNING`, exited 0, action's `!= SUCCEEDED` check fired `exit 1`. 
