### PR TITLE
fix(action): bump setup-apify-cli-action to @v1 (drop Node 20 mise-action)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -43,7 +43,7 @@ runs:
         echo "::error title=⛔ error hint::Support Linux Only"
         exit 1
     - name: Set up Apify CLI
-      uses: apify/setup-apify-cli-action@v1.0.0
+      uses: apify/setup-apify-cli-action@v1
       with:
         token: ${{ inputs.token }}
     - name: Push the Actor


### PR DESCRIPTION
## What

Bumps the pinned `apify/setup-apify-cli-action` from the immutable `@v1.0.0` tag to the floating `@v1` tag.

## Why

`setup-apify-cli-action@v1.0.0` still pins `jdx/mise-action@v2`, which is a Node.js 20 build. As of [GitHub's Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), every run of this action emits:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: jdx/mise-action@v2.
```

The source of `setup-apify-cli-action` is already fixed — its `v1`, `v1.1.0`, and `main` all use `mise-action@v4` (Node 24). The warning persists here purely because we pin the one stale `v1.0.0` release. Tracking the floating `@v1` tag picks up the fix and avoids going stale on future patches.

- Closes #23